### PR TITLE
Remove the TAG from the groups responsible for this document.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This repository contains the [Editor's Draft](https://w3ctag.github.io/security-questionnaire/) of the [Self-Review Questionnaire: Security and Privacy](https://www.w3.org/TR/security-privacy-questionnaire/) document, which spec authors can use to identify and work through possible security and privacy concerns related to their spec.
 
-The questionnaire is a joint product of three groups: the [TAG](https://tag.w3.org/), [PING](https://www.w3.org/Privacy/IG/), and the [Security Interest Group](https://www.w3.org/groups/ig/security/).
+The questionnaire is a joint product of two groups: the [Privacy Working Group](https://www.w3.org/groups/wg/privacy/), and the [Security Interest Group](https://www.w3.org/groups/ig/security/).
 
 When folks request a [design review](https://github.com/w3ctag/design-reviews) from the TAG, [filling out](questionnaire.markdown) the security and privacy questionnaire helps the TAG to understand potential security and privacy issues and mitigations for the design, and can save us asking redundant questions.
 
@@ -14,6 +14,3 @@ writing of those sections, it is not appropriate to merely copy this
 questionnaire into those sections.
 
 [Further instructions on requesting security and privacy reviews can be found in the Guide.](https://w3c.github.io/documentreview/#how_to_get_horizontal_review)
-
-
-

--- a/index.bs
+++ b/index.bs
@@ -6,13 +6,13 @@ ED: https://w3ctag.github.io/security-questionnaire/
 Shortname: security-privacy-questionnaire
 Repository: w3ctag/security-questionnaire
 Level: None
-Editor: Theresa O’Connor, w3cid 40614, Apple Inc. https://apple.com, hober@apple.com
 Editor: Peter Snyder, w3cid 109401, Brave Software https://brave.com, pes@brave.com
 Former Editor: Jason Novak, Apple Inc., https://apple.com
 Former Editor: Lukasz Olejnik, Independent researcher, https://lukaszolejnik.com
 Former Editor: Mike West, Google Inc., mkwst@google.com
+Former Editor: Theresa O’Connor, w3cid 40614, Apple Inc. https://apple.com, hober@apple.com
 Former Editor: Yan Zhu, Yahoo Inc., yan@brave.com
-Group: tag
+Group: privacywg
 Markup Shorthands: css no, markdown yes
 Local Boilerplate: status yes
 Local Boilerplate: copyright yes
@@ -1327,9 +1327,6 @@ practices before the site prompted for location.
 
 <h2 id="acknowledgements" class="no-num">Acknowledgements</h2>
 
-<!-- Current TAG participants who would otherwise be ackked are
-     commented out. Please uncomment them when their term on the TAG
-     ends! -->
 Many thanks to
 Alice Boxhall,
 Alex Russell,
@@ -1337,15 +1334,15 @@ Anne van Kesteren,
 Chris Cunningham,
 Coralie Mercier,
 Corentin Wallez,
-<!-- Daniel Appelquist, -->
+Daniel Appelquist,
 David Baron,
 Domenic Denicola,
 Dominic Battre,
-<!-- Hadley Beeman, -->
+Hadley Beeman,
 Jeffrey Yasskin,
 Jeremy Roman,
 Jonathan Kingston,
-<!-- Kenneth Rohde Christiansen, -->
+Kenneth Rohde Christiansen,
 Marcos Caceres,
 Marijn Kruisselbrink,
 Mark Nottingham,
@@ -1355,12 +1352,12 @@ Mike Perry,
 Nick Doty,
 Robert Linder,
 Piotr Bialecki,
-<!-- Rossen Atanassov, -->
+Rossen Atanassov,
 Samuel Weiler,
-<!-- Sangwhan Moon, -->
+Sangwhan Moon,
 Tantek Çelik,
 Thomas Steiner,
-<!-- Yves Lafon, -->
+Yves Lafon,
 Wendy Seltzer,
 and
 the many current and former participants in PING, the Privacy Working Group,

--- a/status.include
+++ b/status.include
@@ -1,6 +1,6 @@
 <p><em>This section describes the status of this document at the time of its publication. A list of current W3C publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/">W3C technical reports index</a> at https://www.w3.org/TR/.</em></p>
 
-<p>This document was published by the <a href="https://www.w3.org/groups/other/tag">Technical Architecture Group</a>, the <a href="https://www.w3.org/groups/wg/privacy">Privacy Working Group</a>, and the <a href="https://www.w3.org/groups/ig/security/">Security Interest Group</a> as a Group Note using the Note track.</p>
+<p>This document was published by the <a href="https://www.w3.org/groups/wg/privacy">Privacy Working Group</a> and the <a href="https://www.w3.org/groups/ig/security/">Security Interest Group</a> as a Group Note using the Note track.</p>
 
   <p>Group Notes are not endorsed by <abbr title="World Wide Web Consortium">W3C</abbr> nor its Members. </p>
 
@@ -20,7 +20,7 @@
     <a href="https://github.com/[REPOSITORY]/">GitHub repository</a>.
   </p>
 
-  <p data-deliverer="34270,160680,49310">
+  <p data-deliverer="160680,49310">
     The <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a> does not carry any licensing requirements or commitments on this document.
   </p>
 

--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
 {
-    "group": ["other/tag", "wg/privacy"],
-    "contacts": ["tjwhalen", "ylafon"],
+    "group": ["wg/privacy", "ig/security"],
+    "contacts": ["tjwhalen", "simoneonofri"],
     "repo-type": "note"
 }


### PR DESCRIPTION
We shouldn't merge this until the Security IG has appointed an editor, but here are the changes that will need to happen.